### PR TITLE
Change buttons to unordered list

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,13 @@
                     <h3>ささくらり</h3>
                     <p>生年月日: 2005 年 5 月 30 日 (18歳)</p>
                     <p>好きな食べ物: パスタ</p>
-                    <div class="buttons">
-                        <a href="mailto:i@sasakulab.com" class="btn btn-icon-mail" style="background-color: #15918d;">Mail</a>
-                        <a href="https://x.com/sasakulari" class="btn btn-icon-twitter" style="background-color: #1b9df0;">Twitter(X)</a>
-                        <a href="https://github.com/sasakulari" class="btn btn-icon-gh" style="background-color: black;">GitHub</a>
-                        <a href="https://mstdn.soine.site/@sasakulari" class="btn btn-icon-mstdn" style="background-color: #6364ff;">@sasakulari@soine.site</a>
-                        <a href="https://discord.com/channels/@me" class="btn btn-icon-dc" style="background-color: #5865f2;">Discord (@sasakulari)</a>
-                    </div>
+                    <ul class="buttons">
+                        <li><a href="mailto:i@sasakulab.com" class="btn btn-icon-mail" style="background-color: #15918d;">Mail</a></li>
+                        <li><a href="https://x.com/sasakulari" class="btn btn-icon-twitter" style="background-color: #1b9df0;">Twitter(X)</a></li>
+                        <li><a href="https://github.com/sasakulari" class="btn btn-icon-gh" style="background-color: black;">GitHub</a></li>
+                        <li><a href="https://mstdn.soine.site/@sasakulari" class="btn btn-icon-mstdn" style="background-color: #6364ff;">@sasakulari@soine.site</a></li>
+                        <li><a href="https://discord.com/channels/@me" class="btn btn-icon-dc" style="background-color: #5865f2;">Discord (@sasakulari)</a></li>
+                    </ul>
                 </div>
             </div>
             <a href="./profile.html" class="other"> >> 詳しいプロフィールを見る</a>

--- a/profile.html
+++ b/profile.html
@@ -16,7 +16,7 @@
 <body>
         <h1 style="display: none;"><a href="/"><img src="/assets/icon.svg" alt="Sasakulab" width="150px"></a></h1>
         <div class="contents">
-            <a href="/"><< トップページにもどる</a>
+            <a href="/">&lt;&lt; トップページにもどる</a>
             <h2>ささくらり</h2>
             <div class="profiled">
                 <div class="abstract">

--- a/profile.html
+++ b/profile.html
@@ -23,12 +23,12 @@
                     <img src="/assets/kulari.png" alt="ささくらりのアバター">
                     <p>日本に住む人間。別にパンダが好きなわけではない。</p>
                 </div>
-                <div class="buttons center">
-                    <a href="mailto:i@sasakulab.com" class="btn btn-icon-mail" style="background-color: #15918d;">Mail</a>
-                    <a href="https://x.com/sasakulari" class="btn btn-icon-twitter" style="background-color: #1b9df0;">Twitter(X)</a>
-                    <a href="https://github.com/sasakulari" class="btn btn-icon-gh" style="background-color: black;">GitHub</a>
-                    <a href="https://mstdn.soine.site/@sasakulari" class="btn btn-icon-mstdn" style="background-color: #6364ff;">@sasakulari@soine.site</a>
-                </div>
+                <ul class="buttons center">
+                    <li><a href="mailto:i@sasakulab.com" class="btn btn-icon-mail" style="background-color: #15918d;">Mail</a></li>
+                    <li><a href="https://x.com/sasakulari" class="btn btn-icon-twitter" style="background-color: #1b9df0;">Twitter(X)</a></li>
+                    <li><a href="https://github.com/sasakulari" class="btn btn-icon-gh" style="background-color: black;">GitHub</a></li>
+                    <li><a href="https://mstdn.soine.site/@sasakulari" class="btn btn-icon-mstdn" style="background-color: #6364ff;">@sasakulari@soine.site</a></li>
+                </ul>
                 <h3>概要</h3>
                 <ul>
                     <li>誕生日: 5月30日 (18歳)</li>

--- a/style/main.css
+++ b/style/main.css
@@ -99,8 +99,14 @@ h1 {
     margin-top: 18px;
     margin-bottom: 18px;
 
+    padding: unset;
+
     line-height: 52px;
     text-align: center;
+}
+
+.buttons>* {
+    display: unset;
 }
 
 .btn {


### PR DESCRIPTION
`div.buttons` を `ul.buttons` に変更し、その子要素を `li` で囲みました。この変更はモダンブラウザの多くでは見た目に影響を及ぼしませんが、テキストブラウザ等におけるユーザの体験を向上させます（画像は左が旧来、右が変更後）。

<img src="https://github.com/sasakulab/sasakulab.com_v2/assets/48670724/f772aa5c-3d75-47aa-8340-5015a6bd814f" width="49%" alt="旧来">
<img src="https://github.com/sasakulab/sasakulab.com_v2/assets/48670724/42d6a74b-d560-4b48-ae6c-8b117968530e" width="49%" alt="変更後">

また、文字 `<` を表示の目的で利用していると思しきものを発見したため、文字参照に置換しました。
